### PR TITLE
Don't search MAVLINK_STX with last char of bad packet

### DIFF
--- a/mavlink_helpers.h
+++ b/mavlink_helpers.h
@@ -992,12 +992,6 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
 	    _mav_parse_error(status);
 	    status->msg_received = MAVLINK_FRAMING_INCOMPLETE;
 	    status->parse_state = MAVLINK_PARSE_STATE_IDLE;
-	    if (c == MAVLINK_STX)
-	    {
-		    status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
-		    rxmsg->len = 0;
-		    mavlink_start_checksum(rxmsg);
-	    }
 	    return 0;
     }
     return msg_received;


### PR DESCRIPTION
The deleted code always causes extremely occasional packet loss. Details are as follows.
User A add a new mavlink message, but user B din't add the message. This common situation will lead to extremely occasional packet loss in user B. When user B receive the undefined message, mavlink_parse_char() will enter MAVLINK_FRAMING_BAD_CRC status, and check the undefined message last char. If the last char happens to be MAVLINK_STX value, then the subsequent valid packets will parse wrong and lost.